### PR TITLE
Favor `initialize` over `load`

### DIFF
--- a/Providers/Facebook/SimpleAuthFacebookProvider.m
+++ b/Providers/Facebook/SimpleAuthFacebookProvider.m
@@ -15,10 +15,8 @@
 
 #pragma mark - NSObject
 
-+ (void)load {
-    @autoreleasepool {
-        [SimpleAuth registerProviderClass:self];
-    }
++ (void)initialize {
+    [SimpleAuth registerProviderClass:self];
 }
 
 

--- a/Providers/Instagram/SimpleAuthInstagramProvider.m
+++ b/Providers/Instagram/SimpleAuthInstagramProvider.m
@@ -18,10 +18,8 @@
 
 #pragma mark - NSObject
 
-+ (void)load {
-    @autoreleasepool {
-        [SimpleAuth registerProviderClass:self];
-    }
++ (void)initialize {
+    [SimpleAuth registerProviderClass:self];
 }
 
 

--- a/Providers/Meetup/SimpleAuthMeetupProvider.m
+++ b/Providers/Meetup/SimpleAuthMeetupProvider.m
@@ -17,10 +17,8 @@
 
 #pragma mark - NSObject
 
-+ (void)load {
-    @autoreleasepool {
-        [SimpleAuth registerProviderClass:self];
-    }
++ (void)initialize {
+    [SimpleAuth registerProviderClass:self];
 }
 
 #pragma mark - SimpleAuthProvider

--- a/Providers/Twitter/SimpleAuthTwitterProvider.m
+++ b/Providers/Twitter/SimpleAuthTwitterProvider.m
@@ -18,10 +18,8 @@
 
 #pragma mark - NSObject
 
-+ (void)load {
-    @autoreleasepool {
-        [SimpleAuth registerProviderClass:self];
-    }
++ (void)initialize {
+    [SimpleAuth registerProviderClass:self];
 }
 
 

--- a/Providers/TwitterWeb/SimpleAuthTwitterWebProvider.m
+++ b/Providers/TwitterWeb/SimpleAuthTwitterWebProvider.m
@@ -19,10 +19,8 @@
 
 #pragma mark - SimpleAuthProvider
 
-+ (void)load {
-    @autoreleasepool {
-        [SimpleAuth registerProviderClass:self];
-    }
++ (void)initialize {
+    [SimpleAuth registerProviderClass:self];
 }
 
 


### PR DESCRIPTION
`load` method calls are blocking and occur when the application is launched regardless of if the class is every used. `initialize` methods are only called the first time the class is actually used. `initialize` is also more future-proof because you can safely call any method on any class, while you can't reference classes other than the one you're currently implementing inside of `load` due to the runtime not being fully initialized.

Learned this from Matt Galloway's [Effective Objective-C 2.0](http://www.effectiveobjectivec.com) book.
