### PR TITLE
Added re-auth for tokens that expire

### DIFF
--- a/Providers/Facebook/SimpleAuthFacebookProvider.m
+++ b/Providers/Facebook/SimpleAuthFacebookProvider.m
@@ -130,7 +130,8 @@
     if (location) {
         user[@"location"] = location;
     }
-    user[@"verified"] = remoteAccount[@"verified"];
+    if (remoteAccount[@"verified"])
+        user[@"verified"] = remoteAccount[@"verified"];
     user[@"urls"] = @{
         @"Facebook" : remoteAccount[@"link"],
     };

--- a/SimpleAuth/SimpleAuth.h
+++ b/SimpleAuth/SimpleAuth.h
@@ -92,4 +92,28 @@ extern NSString * const SimpleAuthEndActivityBlockKey;
  */
 + (void)authorize:(NSString *)provider options:(NSDictionary *)options completion:(SimpleAuthRequestHandler)completion;
 
+/**
+ Perform re-authorization with the given provider and all previously configured
+ and default provider options. This is for providers where the token expires and you
+ want to renew the non expired token.
+ 
+ @param token the unexpired token recieved from the service
+ @param completion Called on the main queue when the operation is complete.
+ 
+ @see +authorize:options:completion:
+ */
++ (void)reAuthorize:(NSString *)provider token:(NSString *)token completion:(SimpleAuthRequestHandler)completion;
+
+/**
+ Perform re-authorization with the given provider and all previously configured
+ and default provider options. This is for providers where the token expires and you
+ want to renew the non expired token.
+ 
+ @param token the unexpired token recieved from the service
+ @param completion Called on the main queue when the operation is complete.
+ 
+ @see +authorize:options:completion:
+ */
++ (void)reAuthorize:(NSString *)type options:(NSDictionary *)options token:(NSString *)token completion:(SimpleAuthRequestHandler)completion;
+
 @end

--- a/SimpleAuth/SimpleAuth.m
+++ b/SimpleAuth/SimpleAuth.m
@@ -68,6 +68,35 @@ NSString * const SimpleAuthRedirectURIKey = @"redirect_uri";
 }
 
 
++ (void)reAuthorize:(NSString *)type token:(NSString *)token completion:(SimpleAuthRequestHandler)completion {
+    [self reAuthorize:type options:nil token:token completion:completion];
+}
+
+
++ (void)reAuthorize:(NSString *)type options:(NSDictionary *)options token:(NSString *)token completion:(SimpleAuthRequestHandler)completion{
+    // Load the provider class
+    Class klass = [self providers][type];
+    NSAssert(klass, @"There is no class registered to handle %@ requests.", type);
+    
+    // Create options dictionary
+    NSDictionary *defaultOptions = [klass defaultOptions];
+    NSDictionary *registeredOptions = [self configuration][type];
+    NSMutableDictionary *resolvedOptions = [NSMutableDictionary new];
+    [resolvedOptions addEntriesFromDictionary:defaultOptions];
+    [resolvedOptions addEntriesFromDictionary:registeredOptions];
+    [resolvedOptions addEntriesFromDictionary:options];
+    
+    // Create the provider and run authorization
+    SimpleAuthProvider *provider = [(SimpleAuthProvider *)[klass alloc] initWithOptions:resolvedOptions];
+    [provider reAuthorizeWithToken:token completionHandler:^(id responseObject, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(responseObject, error);
+        });
+        [provider class]; // Kepp the provider around until the callback is complete
+    }];
+}
+
+
 #pragma mark - Internal
 
 + (void)registerProviderClass:(Class)klass {

--- a/SimpleAuth/SimpleAuthProvider.h
+++ b/SimpleAuth/SimpleAuthProvider.h
@@ -20,5 +20,6 @@
 
 - (instancetype)initWithOptions:(NSDictionary *)options;
 - (void)authorizeWithCompletion:(SimpleAuthRequestHandler)completion;
+- (void)reAuthorizeWithToken:(NSString *)token completionHandler:(SimpleAuthRequestHandler)completion;
 
 @end

--- a/SimpleAuth/SimpleAuthProvider.m
+++ b/SimpleAuth/SimpleAuthProvider.m
@@ -43,6 +43,11 @@
     [self doesNotRecognizeSelector:_cmd];
 }
 
+- (void)reAuthorizeWithToken:(NSString *)token completionHandler:(SimpleAuthRequestHandler)completion {
+    // Provider doesn't have a re authorize token method setup revert back to standard authorization
+    [self authorizeWithCompletion:completion];
+}
+
 
 #pragma mark - Accessors
 

--- a/SimpleAuthDemo/SADAppDelegate.m
+++ b/SimpleAuthDemo/SADAppDelegate.m
@@ -51,6 +51,7 @@
     
     // app_id is required
     SimpleAuth.configuration[@"facebook"] = @{};
+    // app_secret optional required for re-authorization of token
     SimpleAuth.configuration[@"facebook-web"] = @{};
 	
     // client_id and redirect_uri are required

--- a/SimpleAuthDemo/SADProviderListViewController.m
+++ b/SimpleAuthDemo/SADProviderListViewController.m
@@ -10,7 +10,9 @@
 
 #import "SimpleAuth.h"
 
-@interface SADProviderListViewController ()
+@interface SADProviderListViewController () {
+    NSMutableDictionary *tokens;
+}
 
 @end
 


### PR DESCRIPTION
Added re-auth for tokens that expire by adding a new method that allows a user to pass in an existing token returning a new token with a later expiration date.  If provider does not have this method code reverts to the normal login method for provider. This fixes issue #30
