### PR TITLE
Added LinkedIn to the podspec

### DIFF
--- a/SimpleAuth.podspec
+++ b/SimpleAuth.podspec
@@ -84,4 +84,11 @@ Pod::Spec.new do |s|
     ss.source_files = 'Providers/DropboxWeb/**/*.{h,m}'
     ss.frameworks = 'UIKit'
   end
+  
+  s.subspec 'LinkedInWeb' do |ss|
+    ss.dependency 'SimpleAuth/Core'
+    
+    ss.source_files = 'Providers/LinkedIn/**/*.{h,m}'
+    ss.frameworks = 'UIKit'
+  end
 end


### PR DESCRIPTION
The issue #23 was closed but the LinkedIn provider is not in the Podspec so that provider is not installed. I don't know if there is any reason but here I make the changes. 

Also it would be helpful to make the names of providers consistent. The are some that finish with 'web' and others that not. It makes sense when there is more than one (system and web) but in the others I don't know. (tumblr and instagram vs. foursquareweb)

;)
