### PR TITLE
fixes Foursquare versioning bug

### DIFF
--- a/Providers/FoursquareWeb/SimpleAuthFoursquareWebProvider.m
+++ b/Providers/FoursquareWeb/SimpleAuthFoursquareWebProvider.m
@@ -98,7 +98,7 @@
     return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
         NSDictionary *parameters = @{ @"oauth_token" : accessToken };
         NSString *query = [CMDQueryStringSerialization queryStringWithDictionary:parameters];
-        NSString *URLString = [NSString stringWithFormat:@"https://api.foursquare.com/v2/users/self?%@", query];
+        NSString *URLString = [NSString stringWithFormat:@"https://api.foursquare.com/v2/users/self?v=20140210&%@", query];
         NSURL *URL = [NSURL URLWithString:URLString];
         NSURLRequest *request = [NSURLRequest requestWithURL:URL];
         [NSURLConnection sendAsynchronousRequest:request queue:self.operationQueue


### PR DESCRIPTION
Hi,

From Foursquare documentation:
`As of January 28, 2014, requests that do not include a  v parameter will be rejected.`

I didn't see that one coming, so I updated the provider in order for it to work. :)

Also, any news on issue #17? Have you got any plan for the implementation of SSO providers? (Facebook, etc.)

Thanks,
Julien
