### PR TITLE
Add the ACFacebookAudienceKey in the native facebook provider

### DIFF
--- a/Providers/Facebook/SimpleAuthFacebookProvider.m
+++ b/Providers/Facebook/SimpleAuthFacebookProvider.m
@@ -24,7 +24,8 @@
 
 + (NSDictionary *)defaultOptions {
     return @{
-        @"permissions" : @[ @"email" ]
+        @"permissions" : @[ @"email" ],
+        @"audience" : @[ACFacebookAudienceOnlyMe]
     };
 }
 
@@ -52,7 +53,8 @@
 - (RACSignal *)allSystemAccounts {
     NSDictionary *options = @{
         ACFacebookAppIdKey : self.options[@"app_id"],
-        ACFacebookPermissionsKey : self.options[@"permissions"]
+        ACFacebookPermissionsKey : self.options[@"permissions"],
+        ACFacebookAudienceKey: self.options[@"audience"]
     };
     return [ACAccountStore SimpleAuth_accountsWithTypeIdentifier:ACAccountTypeIdentifierFacebook options:options];
 }


### PR DESCRIPTION
I added the option to specify the ACFacebookAudienceKey when requesting the token. It's necessary when requesting the publish permissions. 

I also change the default options to reflect this change so if the developer don't specify this new option all should behave has always. 
