### PR TITLE
Fix a crash when Foursquare user has not set his lastName, firstName or photo

### DIFF
--- a/Providers/FoursquareWeb/SimpleAuthFoursquareWebProvider.m
+++ b/Providers/FoursquareWeb/SimpleAuthFoursquareWebProvider.m
@@ -145,9 +145,9 @@
     
     // User info
     NSMutableDictionary *user = [NSMutableDictionary new];
-    user[@"first_name"] = userData[@"firstName"];
-    user[@"last_name"] = userData[@"lastName"];
-    user[@"photo"] = userData[@"photo"];
+    user[@"first_name"] = userData[@"firstName"] ?: [NSNull null];
+    user[@"last_name"] = userData[@"lastName"] ?: [NSNull null];
+    user[@"photo"] = userData[@"photo"] ?: [NSNull null];
     dictionary[@"user_info"] = user;
     
     return dictionary;


### PR DESCRIPTION
Simple fix to avoid "attempt to insert nil object"
