### PR TITLE
Fix google provider crash on empty gender/link fields

### DIFF
--- a/Pod/Providers/GoogleWeb/SimpleAuthGoogleWebProvider.m
+++ b/Pod/Providers/GoogleWeb/SimpleAuthGoogleWebProvider.m
@@ -177,16 +177,20 @@
     user[@"name"] = account[@"name"];
     user[@"first_name"] = account[@"given_name"];
     user[@"last_name"] = account[@"family_name"];
-    user[@"gender"] = account[@"gender"];
+    if (account[@"gender"]) {
+        user[@"gender"] = account[@"gender"];
+    }
     
     user[@"image"] = account[@"picture"];
     if (location) {
         user[@"location"] = location;
     }
     user[@"verified"] = account[@"verified_email"] ? @YES : @NO;
-    user[@"urls"] = @{
-                      @"Google +" : account[@"link"],
-                      };
+    if (account[@"link"]) {
+        user[@"urls"] = @{
+                          @"Google +" : account[@"link"],
+                          };
+    }
     
     dictionary[@"info"] = user;
     


### PR DESCRIPTION
Gender and link fields appears to be optional.