### PR TITLE
Fix Facebook provider authorizeWithCompletion method crash

### DIFF
--- a/Pod/Providers/Facebook/SimpleAuthFacebookProvider.m
+++ b/Pod/Providers/Facebook/SimpleAuthFacebookProvider.m
@@ -30,8 +30,8 @@
     [[[[self systemAccount]
         flattenMap:^RACStream *(ACAccount *account) {
             NSArray *signals = @[
-                [RACSignal return:account],
-                [self remoteAccountWithSystemAccount:account]
+                [self remoteAccountWithSystemAccount:account],
+                [RACSignal return:account]
             ];
             return [self rac_liftSelector:@selector(responseDictionaryWithRemoteAccount:systemAccount:) withSignalsFromArray:signals];
         }]


### PR DESCRIPTION
responseDictionaryWithRemoteAccount:systemAccount: method signature require remote account first, then local account.