### PR TITLE
SimpleAuthGoogleWebProvider.m: do not crash if account fields are not…

### DIFF
--- a/Pod/Providers/GoogleWeb/SimpleAuthGoogleWebProvider.m
+++ b/Pod/Providers/GoogleWeb/SimpleAuthGoogleWebProvider.m
@@ -165,10 +165,6 @@
     dictionary[@"extra"] = @{
                              @"raw_info" : account
                              };
-    
-    // Location
-    NSString *location = account[@"location"][@"name"];
-    
     // User info
     NSMutableDictionary *user = [NSMutableDictionary new];
     if (account[@"email"]) {
@@ -177,16 +173,20 @@
     user[@"name"] = account[@"name"];
     user[@"first_name"] = account[@"given_name"];
     user[@"last_name"] = account[@"family_name"];
-    user[@"gender"] = account[@"gender"];
+    if (account[@"gender"]) {
+      user[@"gender"] = account[@"gender"];
+    }
     
     user[@"image"] = account[@"picture"];
-    if (location) {
-        user[@"location"] = location;
+    if (account[@"location"] && account[@"location"][@"name"]) {
+      user[@"location"] = account[@"location"][@"name"];
     }
     user[@"verified"] = account[@"verified_email"] ? @YES : @NO;
-    user[@"urls"] = @{
-                      @"Google +" : account[@"link"],
-                      };
+    if (account[@"link"]) {
+      user[@"urls"] = @{
+        @"Google +" : account[@"link"],
+      };
+    }
     
     dictionary[@"info"] = user;
     


### PR DESCRIPTION
I have been using this and got a crash when I logged in for the first time. Google did not populate all the values, and objectForKey (which is what the assignment does below) cannot handle null values so the library would crash.

My profile came back as:
info = {
 email = "jbicket@samsara.com";
 "first_name" = John;
 image = "https://lh5.googleusercontent.com/-hTUulT9CemI/AAAAAAAAAAI/AAAAAAAAABs/o6pMlpQ0Lvk/photo.jpg";
 "last_name" = Bicket;
 name = "John Bicket";
 verified = 1;
};
