### PR TITLE
Add default fields for Facebook api v2.4

### DIFF
--- a/Pod/Providers/Facebook/SimpleAuthFacebookProvider.m
+++ b/Pod/Providers/Facebook/SimpleAuthFacebookProvider.m
@@ -66,7 +66,7 @@
     return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
         NSURL *URL = [NSURL URLWithString:@"https://graph.facebook.com/me"];
         NSDictionary *parameters = @{
-            @"fields" : @"name,last_name,verified,email,link"
+            @"fields" : @"name,first_name,last_name,verified,email,location,link"
         };
         SLRequest *request = [SLRequest requestForServiceType:SLServiceTypeFacebook requestMethod:SLRequestMethodGET URL:URL parameters:parameters];
         request.account = account;
@@ -133,24 +133,24 @@
     dictionary[@"first_name"] = remoteAccount[@"first_name"];
     dictionary[@"last_name"] = remoteAccount[@"last_name"];
     dictionary[@"verified"] = remoteAccount[@"verified"] ?: @NO;
-    
+
     id email = remoteAccount[@"email"];
     if (email) {
         dictionary[@"email"] = email;
     }
-    
+
     id location = remoteAccount[@"location"][@"name"];
     if (location) {
         dictionary[@"location"] = location;
     }
-    
+
     dictionary[@"urls"] = @{
         @"Facebook": remoteAccount[@"link"]
     };
-    
+
     NSString *avatar = [NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?type=large", remoteAccount[@"id"]];
     dictionary[@"image"] = avatar;
-    
+
     return dictionary;
 }
 

--- a/Pod/Providers/Facebook/SimpleAuthFacebookProvider.m
+++ b/Pod/Providers/Facebook/SimpleAuthFacebookProvider.m
@@ -65,7 +65,10 @@
 - (RACSignal *)remoteAccountWithSystemAccount:(ACAccount *)account {
     return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
         NSURL *URL = [NSURL URLWithString:@"https://graph.facebook.com/me"];
-        SLRequest *request = [SLRequest requestForServiceType:SLServiceTypeFacebook requestMethod:SLRequestMethodGET URL:URL parameters:nil];
+        NSDictionary *parameters = @{
+            @"fields" : @"name,last_name,verified,email,link"
+        };
+        SLRequest *request = [SLRequest requestForServiceType:SLServiceTypeFacebook requestMethod:SLRequestMethodGET URL:URL parameters:parameters];
         request.account = account;
         [request performRequestWithHandler:^(NSData *data, NSHTTPURLResponse *response, NSError *connectionError) {
             NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(200, 99)];

--- a/Pod/Providers/FacebookWeb/SimpleAuthFaceBookWebProvider.m
+++ b/Pod/Providers/FacebookWeb/SimpleAuthFaceBookWebProvider.m
@@ -101,7 +101,10 @@
 
 - (RACSignal *)accountWithAccessToken:(NSDictionary *)accessToken {
     return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
-        NSDictionary *parameters = @{ @"access_token" : accessToken[@"access_token"] };
+        NSDictionary *parameters = @{
+            @"access_token" : accessToken[@"access_token"],
+            @"fields" : @"name,first_name,last_name,verified,email,location,link"
+        };
         NSString *URLString = [NSString stringWithFormat:
                                @"https://graph.facebook.com/me?%@",
                                [CMDQueryStringSerialization queryStringWithDictionary:parameters]];


### PR DESCRIPTION
In v2.4 of the Facebook Graph API you need to explicitly state which fields you want in the graph api response

> Fewer default fields for faster performance: To help improve performance on mobile network connections, we've reduced the number of fields that the API returns by default. You should now use the ?fields=field1,field2 syntax to declare all the fields you want the API to return.
> https://developers.facebook.com/blog/post/2015/07/08/graph-api-v2.4/

So calls to https://graph.facebook.com/me only return the id and name fields by default (for app_id's created since FB deprecated 2.3 - July 8th I think), this causes:

`'NSInvalidArgumentException', reason: '*** setObjectForKey: object cannot be nil (key: first_name)'` like in: [/adamjmcgrath/react-native-simple-auth/issues/5](/adamjmcgrath/react-native-simple-auth/issues/5)

You can reproduce this by using an `app_id` created since they deprecated v2.3 or explicitly pass the version in the url `/v2.4/me`
