### PR TITLE
Adds access_type parameter for GoogleWeb provider

### DIFF
--- a/Pod/Providers/GoogleWeb/SimpleAuthGoogleWebLoginViewController.m
+++ b/Pod/Providers/GoogleWeb/SimpleAuthGoogleWebLoginViewController.m
@@ -25,7 +25,8 @@
         @"client_id" : self.options[@"client_id"],
         @"redirect_uri" : self.options[SimpleAuthRedirectURIKey],
         @"response_type" : @"code",
-        @"scope" : self.options[@"scope"]
+        @"scope" : self.options[@"scope"],
+        @"access_type": self.options[@"access_type"]
     };
     NSString *URLString = [NSString stringWithFormat:
                            @"https://accounts.google.com/o/oauth2/auth?%@",

--- a/Pod/Providers/GoogleWeb/SimpleAuthGoogleWebProvider.m
+++ b/Pod/Providers/GoogleWeb/SimpleAuthGoogleWebProvider.m
@@ -41,6 +41,7 @@
     options[SimpleAuthPresentInterfaceBlockKey] = presentBlock;
     options[SimpleAuthDismissInterfaceBlockKey] = dismissBlock;
     options[SimpleAuthRedirectURIKey] = @"http://localhost";
+    options[@"access_type"] = @"online";
     options[@"scope"] = @"email openid profile";
     return options;
 }
@@ -96,12 +97,19 @@
                                    NSString *token = dictionary[@"access_token"];
                                    if ([token length] > 0) {
                                        
-                                       NSDictionary *credentials = @{
-                                                                     @"access_token" : token,
-                                                                     @"expires" : [NSDate dateWithTimeIntervalSinceNow:[dictionary[@"expires_in"] doubleValue]],
-                                                                     @"token_type" : @"bearer",
-                                                                     @"id_token": dictionary[@"id_token"]
-                                                                     };
+                                       NSMutableDictionary *credentials = [NSMutableDictionary new];
+                                       NSDictionary *defaultCredentials = @{
+                                                                            @"access_token" : token,
+                                                                            @"expires" : [NSDate dateWithTimeIntervalSinceNow:[dictionary[@"expires_in"] doubleValue]],
+                                                                            @"token_type" : @"bearer",
+                                                                            @"id_token": dictionary[@"id_token"]
+                                                                            };
+                                       
+                                      [credentials addEntriesFromDictionary:defaultCredentials];
+                                       if (dictionary[@"refresh_token"]) {
+                                           NSDictionary *refreshToken = @{ @"refresh_token": dictionary[@"refresh_token"] };
+                                           [credentials addEntriesFromDictionary:refreshToken];
+                                       }
                                        
                                        [self userWithCredentials:credentials
                                                       completion:completion];
@@ -153,10 +161,7 @@
     dictionary[@"provider"] = [[self class] type];
     
     // Credentials
-    dictionary[@"credentials"] = @{
-                                   @"token" : credentials[@"access_token"],
-                                   @"expires_at" : credentials[@"expires"]
-                                   };
+    dictionary[@"credentials"] = credentials;
     
     // User ID
     dictionary[@"uid"] = account[@"id"];
@@ -189,6 +194,7 @@
                       };
     
     dictionary[@"info"] = user;
+    
     
     return dictionary;
 }


### PR DESCRIPTION
Adds `access_type` parameter to default options. If nothing was set for this parameter, its default value is `online`. I added this if you want to request a refresh token from Google's Identity Platform then persist it for future use. Also, it passes the credentials as is in the `dictionaryWithAccount` method.

If you think this is a good addition to GoogleWeb provider and will be useful to others, please don't hesitate to merge it. Thanks. 

Reference: [Using OAuth 2.0 to Access Google APIs](https://developers.google.com/identity/protocols/OAuth2)
