### PR TITLE
setup web view through constraints in order to seamless support iPhone X

### DIFF
--- a/Pod/Core/ios/SimpleAuthWebViewController.m
+++ b/Pod/Core/ios/SimpleAuthWebViewController.m
@@ -25,11 +25,20 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.view.backgroundColor = [UIColor whiteColor];
     
-    self.webView.frame = self.view.bounds;
-    [self.view addSubview:self.webView];
+    [self setupWebView];
 }
 
+- (void)setupWebView {
+    [self.view addSubview:self.webView];
+    
+    self.webView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.webView.topAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.topAnchor].active = YES;
+    [self.webView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor].active = YES;
+    [self.webView.bottomAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.bottomAnchor].active = YES;
+    [self.webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor].active = YES;
+}
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
@@ -102,7 +111,6 @@
 - (UIWebView *)webView {
     if (!_webView) {
         _webView = [UIWebView new];
-        _webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
         _webView.delegate = self;
     }
     return _webView;


### PR DESCRIPTION
Setup instagram authorizing controller web view via constraints in order to support iPhone X.
Tested on simulators iPhone X iOS 11, iPhone 6 iOS 10/11.